### PR TITLE
CSS string + instructions to change notes' background to dark theme

### DIFF
--- a/note.color.dark.css
+++ b/note.color.dark.css
@@ -1,0 +1,50 @@
+body {
+color: white;
+max-width: 35em;
+margin: 0 auto;
+padding-left: 20px;
+padding-right: 20px;
+background-color: #474749;
+}
+
+h1 {
+color: white;
+font-size: 1.6em;
+padding-bottom: none;
+}
+
+h2 {
+color: white;
+font-size: 1.4em;
+font-weight: bold;
+padding-bottom: none;
+border-bottom: none;
+}
+
+h3 {
+color: white;
+font-size: 1.2em;
+}
+
+p {
+text-indent: 1.75em;
+}
+
+ul,
+ol {
+padding-left: 1.75em;
+}
+
+blockquote {
+margin-top: 0;
+margin-bottom: 0;
+margin-left: 0;
+padding-left: 1.55em;
+border-left: 3px solid darkgrey;
+color: white (255, 248, 248);
+}
+blockquote p {
+text-indent: 0;
+}
+
+/* end of CSS */

--- a/set_note_color_to_dark.md
+++ b/set_note_color_to_dark.md
@@ -1,0 +1,30 @@
+> Full **credit** for the original css snippet goes to Zotero Forum user **[fbcx](https://forums.zotero.org/profile/7296727/fbcx)**
+> 
+> These are the [original Zotero forum topic](https://forums.zotero.org/discussion/86855/make-note-editor-beautiful) and fbcx's subsequent [comment](https://forums.zotero.org/discussion/86855/make-note-editor-beautiful#Comment_372922)
+---
+
+Follow these steps
+
+1. open Zotero
+
+2. go to Preferences → Advanced → Config Editor
+
+3. "I accept the risks!"
+
+4. search extensions.zotero.note.css and double-click it
+
+5. insert the content of `note.color.dark.css`
+
+6. click 'OK'
+
+7. Close and restart Zotero
+---
+
+Notice that:
+- color for both body and headers text is set to _white_
+
+- background-color is set to _#474749_, which is the shade chosen by Rosmaninho for this dark theme 
+
+- the color of the line for blockquotes is set to _solid darkgrey_ to distinguish it from the background
+
+You may change these parameters by setting different colors in the `note.color.dark.css` string.


### PR DESCRIPTION
This should be able to resolve issue #17 

Instructions on how to set up the string in Zotero can be found in file: 
`set_note_color_to_dark.md`

The string itself is 
`note.color.dark.css`

> Full credit for the original css snippet to Zotero Forum user **fbcx**. The string can be found in this [Zotero forum topic](https://forums.zotero.org/discussion/86855/make-note-editor-beautiful) and this [comment](https://forums.zotero.org/discussion/86855/make-note-editor-beautiful#Comment_372922) . 
I just edited it to match with this theme.