### PR TITLE
Fix #16 Highlighted collection background color

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -109,6 +109,10 @@ color: #FFFFFF !important; border: 0 !important; }
 #zotero-collections-tree treechildren::-moz-tree-cell(selected) { background: #474749 !important; border: 0 !important;
 border-bottom: 1px solid #1d1d1d !important; }
 
+/*change highlight color of collections containing selected items on Ctrl(Win) or Option/Alt(Mac/Linux) press */
+/*Set by setHighlightedRows() and getRowProperties() in collectionTreeView.js)*/
+#zotero-collections-tree treechildren::-moz-tree-row(highlighted){ background: #1B456A !important;}
+
 #zotero-collections-tree treechildren::-moz-tree-cell-text(selected) { color: #FFFFFF !important; }
 
 #zotero-collections-tree treechildren { border-right: 1px solid #1d1d1d !important ; }


### PR DESCRIPTION
Fixes #16  unreadable highlight color (white on a yellow background) to white on a blue background, could change it to any other color to suit the theme if needed.

New highlight color:
![zotero-dark-new-highlight](https://user-images.githubusercontent.com/64446376/143155338-bb776106-9992-4c74-877c-ea58e0958d44.jpg)

